### PR TITLE
use hexadecimal instead of octal escape sequence & patch bump

### DIFF
--- a/lib/pnglib.js
+++ b/lib/pnglib.js
@@ -201,7 +201,7 @@ module.exports = function(width,height,depth) {
         crc32(this.buffer, this.iend_offs, this.iend_size);
 
         // convert PNG to string
-        return "\211PNG\r\n\032\n"+this.buffer.join('');
+        return "\x89PNG\r\n\x1a\n" + this.buffer.join('');
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnglib",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A PNG lib for Node.js",
   "author": {
     "name": "George Chan"


### PR DESCRIPTION
This add support for es5 strict mode, allowing to bundle pnglib without error (rollupjs, webpack, etc.)
