### PR TITLE
support strict mode

### DIFF
--- a/lib/pnglib.js
+++ b/lib/pnglib.js
@@ -12,7 +12,6 @@
 // Modified by George Chan <gchan@21cn.com>
 
 module.exports = function(width,height,depth) {
-    'use strict';
 
     // helper functions for that ctx
     function write(buffer, offs) {

--- a/lib/pnglib.js
+++ b/lib/pnglib.js
@@ -12,7 +12,7 @@
 // Modified by George Chan <gchan@21cn.com>
 
 module.exports = function(width,height,depth) {
-
+    'use strict';
 
     // helper functions for that ctx
     function write(buffer, offs) {
@@ -201,7 +201,8 @@ module.exports = function(width,height,depth) {
         crc32(this.buffer, this.iend_offs, this.iend_size);
 
         // convert PNG to string
-        return "\211PNG\r\n\032\n"+this.buffer.join('');
+        //return "\211PNG\r\n\032\n"+this.buffer.join(''); // Octal literals are not allowed in strict mode. Try it your self @http://www.w3schools.com/js/tryit.asp?filename=tryjs_strict_octal
+        return String.fromCharCode(137) + "PNG\r\n" + String.fromCharCode(26) + "\n" + this.buffer.join('');
     }
 };
 


### PR DESCRIPTION
Fix the error "Octal literals are not allowed in strict mode".
Try it your self @http://www.w3schools.com/js/tryit.asp?filename=tryjs_strict_octal
